### PR TITLE
Fix typo in Gradle dependency example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After your instance is up and running, you have to add Agones Kotlin SDK to your
 ```kotlin
 dependencies {
     // make sure to specify the latest version
-    api("net.scrayos", "agones-client-sdk", "5.1.0-SNAPSHOT")
+    api("net.scrayos", "agones-client-sdk", "5.1.2-SNAPSHOT")
 
     // choose your own gRPC runtime or use an existing one
     runtimeOnly("io.grpc", "grpc-netty", "1.72.0")

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After your instance is up and running, you have to add Agones Kotlin SDK to your
 ```kotlin
 dependencies {
     // make sure to specify the latest version
-    api("net.scrayos", "agones-kotlin-sdk", "5.1.0-SNAPSHOT")
+    api("net.scrayos", "agones-client-sdk", "5.1.0-SNAPSHOT")
 
     // choose your own gRPC runtime or use an existing one
     runtimeOnly("io.grpc", "grpc-netty", "1.72.0")


### PR DESCRIPTION
The `README` had the artifact id listed as `agones-kotlin-sdk`, even though it is actually `agones-client-sdk` (which is a more descriptive name in the context of this being a jvm-library anyway) 

I also updated the version in that snippet to the current version.